### PR TITLE
Aggiornamento mappa dopo che pellet/frutto è stato mangiato #74

### DIFF
--- a/pacman-lib/src/main/scala/it/unibo/scalapacman/lib/engine/GameHelpers.scala
+++ b/pacman-lib/src/main/scala/it/unibo/scalapacman/lib/engine/GameHelpers.scala
@@ -5,6 +5,7 @@ import it.unibo.scalapacman.lib.model.{Character, Ghost, Map, Pacman, Tile}
 import it.unibo.scalapacman.lib.model.Direction.Direction
 import it.unibo.scalapacman.lib.model.Direction.{EAST, NORTH, SOUTH, WEST}
 import it.unibo.scalapacman.lib.engine.CircularMovement.{moveFor, moveUntil}
+import it.unibo.scalapacman.lib.model.Tile.Track
 
 object GameHelpers {
 
@@ -66,6 +67,8 @@ object GameHelpers {
     def nextTile(direction: Direction): Tile = map.tile(character.position, Some(direction).map(CharacterMovement.vector))
 
     def tileIndexes: (Int, Int) = map.tileIndexes(character.position)
+
+    def eat: Map = map.empty(character.tileIndexes)
   }
 
   implicit class MapHelper(map: Map) {
@@ -98,6 +101,18 @@ object GameHelpers {
     private def pacmanEffect(x: Int, max: Int): Int = x match {
       case x: Int if x >= 0 => x % max
       case x: Int => pacmanEffect(x + max, max)
+    }
+
+    def empty(indexes: (Int, Int)): Map = map.copy(
+      tiles = map.tiles.updated(indexes._2, emptyRow(indexes._1, map.tiles(indexes._2)))
+    )
+
+    private def emptyRow(index: Int, row: List[Tile]): List[Tile] =
+      row.updated(index, emptyTile(row(index)))
+
+    private def emptyTile(tile: Tile): Tile = tile match {
+      case Track(Some(_)) => Track(None)
+      case t: Tile => t
     }
   }
 }

--- a/pacman-lib/src/main/scala/it/unibo/scalapacman/lib/engine/GameTick.scala
+++ b/pacman-lib/src/main/scala/it/unibo/scalapacman/lib/engine/GameTick.scala
@@ -1,16 +1,25 @@
 package it.unibo.scalapacman.lib.engine
 
-import it.unibo.scalapacman.lib.model.{Character, Eatable, GameObject, GameState, Map, Pacman}
-import it.unibo.scalapacman.lib.engine.GameHelpers.CharacterHelper
+import it.unibo.scalapacman.lib.model.{Character, Eatable, GameObject, GameState, Map, Pacman, Tile}
+import it.unibo.scalapacman.lib.engine.GameHelpers.{CharacterHelper, MapHelper}
 
 object GameTick {
-  def collisions(characters: List[Character])(implicit map: Map): List[GameObject] =
+  def collisions(characters: List[Character])(implicit map: Map): List[(Character, GameObject)] =
     characters collect { case p: Pacman => p } flatMap characterCollisions(characters)
 
-  private def characterCollisions(characters: List[Character])(character: Character)(implicit map: Map): List[GameObject] =
-    character.tile.eatable ++: characters.filter(_ != character).filter(_.tile eq character.tile)
+  private def characterCollisions(characters: List[Character])(character: Character)(implicit map: Map): List[(Character, GameObject)] =
+    (character.tile.eatable ++: characters.filter(_ != character).filter(_.tile eq character.tile)).map(obj => (character, obj))
 
-  def calculateGameState(collisions: List[GameObject]): GameState = GameState(
-    score = collisions collect { case e: Eatable => e } map (_.points) sum
+  def calculateGameState(gameState: GameState)(implicit collisions: List[(Character, GameObject)]): GameState = GameState(
+    score = (collisions collect { case (_, e: Eatable) => e } map (_.points) sum) + gameState.score
   )
+
+  def calculateMap(map: Map)(implicit collisions: List[(Character, GameObject)]): Map = map.copy(
+    tiles = calculateMapTiles(map, collisions.collect({ case (a: Character, e: Eatable) => (a, e) }))
+  )
+
+  private def calculateMapTiles(map: Map, collisions: List[(Character, Eatable)]): List[List[Tile]] =
+    collisions.map(_._1).foldLeft(map)(calculateMapTile(_, _)).tiles
+
+  private def calculateMapTile(implicit map: Map, character: Character): Map = character.eat
 }

--- a/pacman-lib/src/test/scala/it/unibo/scalapacman/lib/engine/GameTickTest.scala
+++ b/pacman-lib/src/test/scala/it/unibo/scalapacman/lib/engine/GameTickTest.scala
@@ -2,6 +2,8 @@ package it.unibo.scalapacman.lib.engine
 
 import it.unibo.scalapacman.lib.math.{Point2D, TileGeography}
 import it.unibo.scalapacman.lib.model.{Direction, Dot, Fruit, GameState, Ghost, Map, Pacman, Tile}
+import it.unibo.scalapacman.lib.engine.GameTick.{calculateGameState, calculateMap, collisions}
+import it.unibo.scalapacman.lib.engine.GameHelpers.{CharacterHelper, MapHelper}
 import org.scalatest.wordspec.AnyWordSpec
 
 class GameTickTest extends AnyWordSpec {
@@ -23,44 +25,44 @@ class GameTickTest extends AnyWordSpec {
     "evaluate collisions" which {
       "return no results" when {
         "there are only ghosts" in {
-          assert(GameTick.collisions(List(GHOST_1, GHOST_2)).isEmpty)
+          assert(collisions(List(GHOST_1, GHOST_2)).isEmpty)
         }
         "Pacman is alone in its tile" in {
           val pacman = Pacman(PACMAN.position + Point2D(TileGeography.SIZE, 0), 0.0, Direction.EAST)
-          assert(GameTick.collisions(List(pacman, GHOST_1, GHOST_2)).isEmpty)
+          assert(collisions(List(pacman, GHOST_1, GHOST_2)).isEmpty)
         }
         "Pacman's tile is empty" in {
-          assert(GameTick.collisions(List(PACMAN)).isEmpty)
+          assert(collisions(List(PACMAN)).isEmpty)
         }
       }
       "return ghosts" when {
         "they are in the same position" in {
-          val collisions = GameTick.collisions(List(PACMAN, GHOST_1))
-          assert(collisions.size == 1 && collisions.head == GHOST_1)
+          val coll = collisions(List(PACMAN, GHOST_1))
+          assert(coll.size == 1 && coll.head._2 == GHOST_1)
         }
         "they are in a different position but in the same tile" in {
-          val collisions = GameTick.collisions(List(PACMAN, GHOST_2))
-          assert(collisions.size == 1 && collisions.head == GHOST_2)
+          val coll = collisions(List(PACMAN, GHOST_2))
+          assert(coll.size == 1 && coll.head._2 == GHOST_2)
         }
         "they are more than one in Pacman's tile" in {
-          assert(GameTick.collisions(List(PACMAN, GHOST_1, GHOST_2)).size == 2)
+          assert(collisions(List(PACMAN, GHOST_1, GHOST_2)).size == 2)
         }
       }
       "return the tile's game object" when {
         "a fruit is in the Pacman's tile" in {
           val pacman = Pacman(PACMAN.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.SOUTH)
-          val collisions = GameTick.collisions(List(pacman))
-          assert(collisions.size == 1 && collisions.head == Dot.SMALL_DOT)
+          val coll = collisions(List(pacman))
+          assert(coll.size == 1 && coll.head._2 == Dot.SMALL_DOT)
         }
         "a small dot is in the Pacman's tile" in {
           val pacman = Pacman(PACMAN.position + Point2D(0, TileGeography.SIZE * 2), 0.0, Direction.NORTH)
-          val collisions = GameTick.collisions(List(pacman))
-          assert(collisions.size == 1 && collisions.head == Dot.ENERGIZER_DOT)
+          val coll = collisions(List(pacman))
+          assert(coll.size == 1 && coll.head._2 == Dot.ENERGIZER_DOT)
         }
         "an energized dot is in the Pacman's tile" in {
           val pacman = Pacman(PACMAN.position + Point2D(0, TileGeography.SIZE * 3), 0.0, Direction.WEST)
-          val collisions = GameTick.collisions(List(pacman))
-          assert(collisions.size == 1 && collisions.head == Fruit.APPLE)
+          val coll = collisions(List(pacman))
+          assert(coll.size == 1 && coll.head._2 == Fruit.APPLE)
         }
       }
       "return ghosts and tile's game object" when {
@@ -68,33 +70,66 @@ class GameTickTest extends AnyWordSpec {
           var pacman = Pacman(PACMAN.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
           var ghost1 = Ghost(GHOST_1.ghostType, GHOST_1.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
           var ghost2 = Ghost(GHOST_2.ghostType, GHOST_2.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
-          assert(GameTick.collisions(List(pacman, ghost1, ghost2)).size == 3)
+          assert(collisions(List(pacman, ghost1, ghost2)).size == 3)
 
           pacman = Pacman(pacman.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
           ghost1 = Ghost(ghost1.ghostType, ghost1.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
           ghost2 = Ghost(ghost2.ghostType, ghost2.position + Point2D(0, TileGeography.SIZE), 0.0, Direction.EAST)
-          assert(GameTick.collisions(List(pacman, ghost1, ghost2)).size == 3)
+          assert(collisions(List(pacman, ghost1, ghost2)).size == 3)
         }
       }
     }
     "evaluate the new game state" which {
       "calculate gained points" when {
         "pacman collide with a small dot" in {
-          assertResult(OLD_GAME_STATE.score + Dot.SMALL_DOT.points)((OLD_GAME_STATE + GameTick.calculateGameState(Dot.SMALL_DOT :: Nil)).score)
+          assertResult(OLD_GAME_STATE.score + Dot.SMALL_DOT.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Dot.SMALL_DOT) :: Nil).score)
         }
         "pacman collide with an energizer dot" in {
-          assertResult(OLD_GAME_STATE.score + Dot.ENERGIZER_DOT.points)((OLD_GAME_STATE + GameTick.calculateGameState(Dot.ENERGIZER_DOT :: Nil)).score)
+          assertResult(OLD_GAME_STATE.score + Dot.ENERGIZER_DOT.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Dot.ENERGIZER_DOT) :: Nil).score)
         }
         "pacman collide with a fruit" in {
-          assertResult(OLD_GAME_STATE.score + Fruit.APPLE.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.APPLE :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.BELL.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.BELL :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.CHERRIES.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.CHERRIES :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.GALAXIAN.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.GALAXIAN :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.GRAPES.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.GRAPES :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.KEY.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.KEY :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.PEACH.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.PEACH :: Nil)).score)
-          assertResult(OLD_GAME_STATE.score + Fruit.STRAWBERRY.points)((OLD_GAME_STATE + GameTick.calculateGameState(Fruit.STRAWBERRY :: Nil)).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.APPLE.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.APPLE) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.BELL.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.BELL) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.CHERRIES.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.CHERRIES) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.GALAXIAN.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.GALAXIAN) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.GRAPES.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.GRAPES) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.KEY.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.KEY) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.PEACH.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.PEACH) :: Nil).score)
+          assertResult(OLD_GAME_STATE.score + Fruit.STRAWBERRY.points)(calculateGameState(OLD_GAME_STATE)((PACMAN, Fruit.STRAWBERRY) :: Nil).score)
         }
+      }
+    }
+    "evaluate the new map" which {
+      "remove eaten fruits" in {
+        val pacman = PACMAN.copy(position = Point2D(TileGeography.SIZE * 3, TileGeography.SIZE * 3))
+        val newMap = calculateMap(MAP)((pacman, Fruit.APPLE) :: Nil)
+        for (y <- 0 until MAP.width; x <- 0 until MAP.height) {
+          val oldTile = MAP.tiles(y)(x)
+          val newTile = newMap.tiles(y)(x)
+          if (pacman.tileIndexes == (x, y)) assert(oldTile.eatable.isDefined && newTile.eatable.isEmpty) else assert(oldTile == newTile)
+        }
+      }
+      "remove eaten dots" in {
+        val pacman = PACMAN.copy(position = Point2D(TileGeography.SIZE, TileGeography.SIZE))
+        val newMap = calculateMap(MAP)((pacman, Dot.SMALL_DOT) :: Nil)
+        for (y <- 0 until MAP.height; x <- 0 until MAP.width) {
+          val oldTile = MAP.tiles(y)(x)
+          val newTile = newMap.tiles(y)(x)
+          if (pacman.tileIndexes == (x, y)) assert(oldTile.eatable.isDefined && newTile.eatable.isEmpty) else assert(oldTile == newTile)
+        }
+        val pacman2 = PACMAN.copy(position = Point2D(TileGeography.SIZE * 2, TileGeography.SIZE * 2))
+        val newMap2 = calculateMap(MAP)((pacman2, Dot.ENERGIZER_DOT) :: Nil)
+        for (y <- 0 until MAP.height; x <- 0 until MAP.width) {
+          val oldTile = MAP.tiles(y)(x)
+          val newTile = newMap2.tiles(y)(x)
+          if (pacman2.tileIndexes == (x, y)) assert(oldTile.eatable.isDefined && newTile.eatable.isEmpty) else assert(oldTile == newTile)
+        }
+      }
+      "is the same when there are no collisions or only collisions with other characters" in {
+        val noCollisions = Nil
+        assertResult(MAP)(calculateMap(MAP)(noCollisions))
+        val charactersCollisions = (PACMAN, GHOST_1) :: Nil
+        assertResult(MAP)(calculateMap(MAP)(charactersCollisions))
       }
     }
   }


### PR DESCRIPTION
Aggiunge anche due funzioni per rimuovere gli eatable dalla mappa

Closing #74 