### PR TITLE
Modifica carattere con cui viene rappresentato Inky

### DIFF
--- a/client/src/main/scala/it/unibo/scalapacman/client/map/ElementsCode.scala
+++ b/client/src/main/scala/it/unibo/scalapacman/client/map/ElementsCode.scala
@@ -72,8 +72,8 @@ object ElementsCode {
   val GHOST_CODE_PINKY = "P"
   /**
    * Rappresenta fantasma Inky
-   * Carattere I, occupa 1 spazio */
-  val GHOST_CODE_INKY = "I"
+   * Carattere K, occupa 1 spazio */
+  val GHOST_CODE_INKY = "K"
   /**
    * Rappresenta fantasma Clyde
    * Carattere C, occupa 1 spazio */


### PR DESCRIPTION
Modifica carattere con cui viene rappresentato Inky, usando il carattere `I` viene renderizzato male su sistemi Linux